### PR TITLE
1 trocado para 1j em np.allclose

### DIFF
--- a/2020-3/lab/lab1/lab1.ipynb
+++ b/2020-3/lab/lab1/lab1.ipynb
@@ -117,7 +117,7 @@
     "result = job.result()\n",
     "print('Estado gerado pelo circuito: ', result.get_statevector())\n",
     "\n",
-    "np.allclose(result.get_statevector(), [1, 0, 0, 0, 0, 0, 0, 1])"
+    "np.allclose(result.get_statevector(), [1/np.sqrt(2), 0, 0, 0, 0, 0, 0, 1/np.sqrt(2)])"
    ]
   },
   {

--- a/2020-3/lab/lab1/lab1.ipynb
+++ b/2020-3/lab/lab1/lab1.ipynb
@@ -62,7 +62,7 @@
     "result = job.result()\n",
     "print('Estado gerado pelo circuito: ', result.get_statevector())\n",
     "\n",
-    "np.allclose(result.get_statevector(), [1/np.sqrt(3), np.sqrt(2*1j/3)])\n",
+    "np.allclose(result.get_statevector(), [1j/np.sqrt(3), np.sqrt(2*1j/3)])\n",
     "    \n"
    ]
   },


### PR DESCRIPTION
O qubit é **i**/sqrt(3)|0>+sqrt(2i/3)|1> mas o np.allclose está como **1**/sqrt(3)|0>+sqrt(2i/3)|1>